### PR TITLE
Hash each item before doing the comparison.

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,15 +1,14 @@
 package auth
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 )
 
 // SecureCompare performs a constant time compare of two strings to limit timing attacks.
 func SecureCompare(given string, actual string) bool {
-	if subtle.ConstantTimeEq(int32(len(given)), int32(len(actual))) == 1 {
-		return subtle.ConstantTimeCompare([]byte(given), []byte(actual)) == 1
-	} else {
-		/* Securely compare actual to itself to keep constant time, but always return false */
-		return subtle.ConstantTimeCompare([]byte(actual), []byte(actual)) == 1 && false
-	}
+	givenSha := sha256.Sum256([]byte(given))
+	actualSha := sha256.Sum256([]byte(actual))
+
+	return subtle.ConstantTimeCompare(givenSha[:], actualSha[:]) == 1
 }


### PR DESCRIPTION
By taking a hash of the two strings we can guarantee that they'll be the same length when compared by the constant time function. This is a better timing attack mitigation as it removes the branch which has a different instruction count ([see here](https://github.com/codegangsta/martini-contrib/commit/abc2f6607a7f8526b0dea8e1eccf428544f08e49#diff-2144f4c07d50503617dfb64893eaf7b1R13)).
