### PR TITLE
Add token-based authentication.

### DIFF
--- a/token.go
+++ b/token.go
@@ -5,18 +5,18 @@ import (
 	"net/http"
 )
 
-// AuthToken is the authorization token extracted from the request.
-type AuthToken string
+// Token is the authorization token extracted from the request.
+type Token string
 
-// TokenFunc returns a Handler that authenticates via an X-Token header using the provided function.
+// TokenFunc returns a Handler that authenticates via an Authentication: Bearer header using the provided function.
 // The function should return true for a valid token.
 func TokenFunc(authfn func(string) bool) martini.Handler {
 	return func(res http.ResponseWriter, req *http.Request, c martini.Context) {
-		auth := req.Header.Get("X-Token")
-		if len(auth) < 2 || !authfn(auth) {
+		auth := req.Header.Get("Authorization")
+		if len(auth) < 7 || auth[:7] != "Bearer " || !authfn(auth[7:]) {
 			http.Error(res, "Not Authorized", http.StatusUnauthorized)
 			return
 		}
-		c.Map(AuthToken(auth))
+		c.Map(Token(auth[7:]))
 	}
 }

--- a/token.go
+++ b/token.go
@@ -1,0 +1,22 @@
+package auth
+
+import (
+	"github.com/go-martini/martini"
+	"net/http"
+)
+
+// AuthToken is the authorization token extracted from the request.
+type AuthToken string
+
+// TokenFunc returns a Handler that authenticates via an X-Token header using the provided function.
+// The function should return true for a valid token.
+func TokenFunc(authfn func(string) bool) martini.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c martini.Context) {
+		auth := req.Header.Get("X-Token")
+		if len(auth) < 2 || !authfn(auth) {
+			http.Error(res, "Not Authorized", http.StatusUnauthorized)
+			return
+		}
+		c.Map(AuthToken(auth))
+	}
+}


### PR DESCRIPTION
This patch adds authentication based on a passed token, contained in the `X-Token` header. It allows a login endpoint to create a token which can be passed as a header to all subsequent API calls.
